### PR TITLE
[TOOLS-491] Add customName field

### DIFF
--- a/lib/sidechain.js
+++ b/lib/sidechain.js
@@ -1,4 +1,5 @@
 var Common = require('./common');
+const knownSidechainsList = require('../sidechains.json');
 
 function SidechainController(node) {
     this.node = node;
@@ -57,6 +58,8 @@ SidechainController.prototype.getScInfo = function(scid, options, callback) {
 
 SidechainController.prototype.transformSidechain = function (sc) {
     if (sc) {
+        var customName = knownSidechainsList.find(sidechainListItem => sidechainListItem.scid === sc.scid)?.customName;
+        sc.customName = customName ? customName : null;
         return sc
     }
     else {

--- a/sidechains.json
+++ b/sidechains.json
@@ -1,0 +1,6 @@
+[
+  {
+    "scid": "193d31ca4584b01983affb3250e6ce26399930db158d94377fb2dc8db34163e6",
+    "customName": "Web Wallet Sidechain"
+  }
+]

--- a/sidechains.json
+++ b/sidechains.json
@@ -1,6 +1,6 @@
 [
   {
-    "scid": "193d31ca4584b01983affb3250e6ce26399930db158d94377fb2dc8db34163e6",
+    "scid": "066b386efa5a2c54f4c284a1f605851e917974857efed93564e3315517e2dce2",
     "customName": "Web Wallet Sidechain"
   }
 ]


### PR DESCRIPTION
**Jira ticket:** https://horizenlabs.atlassian.net/browse/TOOLS-491

We're adding a `customName` field to the object that the `scinfo` endpoint returns, in order to use it in other places like, for example, Sphere, so users have a friendly way of select the sidechain they want to interact with.

<img width="1401" alt="image" src="https://user-images.githubusercontent.com/36055057/161537502-cc6a205c-69e3-4112-9657-375169710351.png">
