### PR TITLE
Removed invalid address for Mining-Dutch

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -112,8 +112,7 @@
     "poolName": "Mining-Dutch.nl",
     "url": "https://www.mining-dutch.nl/pools/horizen.php",
     "searchStrings": [
-     "znnQPdWkZR8N6hkuHHwB46J6FxXhRwuAapm",
-     "znita7sJ5XFpDnhn2mtXo99cTiySYVSHEJd"
+     "znnQPdWkZR8N6hkuHHwB46J6FxXhRwuAapm"
     ]
   },
   {


### PR DESCRIPTION
The removed address does not belong to Mining-Dutch. It's apparently used by another pool/miner but unsure who or which party